### PR TITLE
Add support of unsigned byte to dump_raw_data

### DIFF
--- a/mhd_utils.py
+++ b/mhd_utils.py
@@ -140,6 +140,8 @@ def dump_raw_data(filename, data, dsize, element_channels=1):
         array_string = 'i'
     elif data.dtype == np.uint32:
         array_string = 'I'
+    elif data.dtype == np.uint8 or data.dtype == np.ubyte:
+        array_string = 'B'
     else:
         raise NotImplementedError("ElementType " + str(data.dtype) + " not implemented.")
     a = array.array(array_string)


### PR DESCRIPTION
Simply added writing unsigned byte to output, which is already supported in `write_mhd_file`